### PR TITLE
fix: combined eyes look vector

### DIFF
--- a/VRCFTOmniceptModule/VRCFTEyeTracking.cs
+++ b/VRCFTOmniceptModule/VRCFTEyeTracking.cs
@@ -80,7 +80,7 @@ public class VRCFTEyeTracking
 
         public VRCFTEye CombinedEye => new(VRCFTEye.EyeType.Combined)
         {
-            Look = new Vector2((LeftEye.Look.x + LeftEye.Look.y) / 2, (RightEye.Look.x + RightEye.Look.y) / 2),
+            Look = new Vector2((LeftEye.Look.x + RightEye.Look.x) / 2, (LeftEye.Look.y + RightEye.Look.y) / 2),
             Openness = (LeftEye.Openness + RightEye.Openness) / 2,
             PupilDilate = (LeftEye.PupilDilate + RightEye.PupilDilate) / 2
         };


### PR DESCRIPTION
First of all: Thanks for making this VRCFT module! It's been my gateway to experiment with eye tracking in VR.



### Bug Description
There's an unwanted up/down movement when looking to the left and right. I narrowed it down to this omnicept module calculating the average Y position of both eyes in a wrong way and proposed a fix.

### Screenshot
(I simulate eye movement only in the X direction, but you can see the `EyesY` parameter in the upper left corner changing as well)

![Animation](https://user-images.githubusercontent.com/25348281/200655986-2539ce89-d5ec-41e0-bad1-7d1f01396978.gif)

### Referenced LOC
https://github.com/200Tigersbloxed/VRCFTOmniceptModule/blob/ee4b10d5e9b5c80862fbd6b46ae47e70c19794d5/VRCFTOmniceptModule/VRCFTEyeTracking.cs#L83
